### PR TITLE
Memoize reducer by wrong curry call removal

### DIFF
--- a/src/create-reducer.js
+++ b/src/create-reducer.js
@@ -31,7 +31,7 @@ const createReducerSpec = compose(
 
 const createReducer = (initialState, spec) => {
   const reducer = createReducerSpec(spec)
-  return (state, action = {}) => reducer(action)(state)
+  return (state, action = {}) => reducer(action)(state || initialState)
 }
 
 export default createReducer

--- a/src/create-reducer.js
+++ b/src/create-reducer.js
@@ -29,9 +29,9 @@ const createReducerSpec = compose(
   map(ensureCondSpec)
 )
 
-const createReducer = curry((initialState, spec, state, action = {}) => {
-  state = (state) ? state : initialState
-  return createReducerSpec(spec)(action)(state)
-})
+const createReducer = (initialState, spec) => {
+  const reducer = createReducerSpec(spec)
+  return (state, action = {}) => reducer(action)(state)
+}
 
 export default createReducer


### PR DESCRIPTION
Without this pull request it recomputes reducer(call all of the transformations on `spec`) on every action dispatch. This pull request caches the computed reducer and uses it across all action dispatches. It removes the currying but on 99% cases it is not necessary here and it wastes resources.